### PR TITLE
Add Jest tests for modules

### DIFF
--- a/__tests__/nameRoutesStreams.test.js
+++ b/__tests__/nameRoutesStreams.test.js
@@ -1,0 +1,34 @@
+const ndlReq = require('../modules/needleSend');
+const { controller } = require('../modules/name-routs-streams');
+
+jest.mock('../modules/needleSend');
+
+describe('name-routs-streams controller', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('calls needleReq with fixed url', () => {
+    ndlReq.needleReq.mockImplementation(() => {});
+    controller(() => {});
+    expect(ndlReq.needleReq).toHaveBeenCalled();
+    const params = ndlReq.needleReq.mock.calls[0][0];
+    expect(params.url).toBe('http://localhost:3000/channels-url');
+    expect(params.method).toBe('GET');
+  });
+
+  test('invokes callback with apTV data on 200', () => {
+    const data = {some: 'value'};
+    ndlReq.needleReq.mockImplementation((p,cb) => cb({statusCode:200, body:{apTV:data}}));
+    const cl = jest.fn();
+    controller(cl);
+    expect(cl).toHaveBeenCalledWith(data);
+  });
+
+  test('does not invoke callback when response undefined', () => {
+    ndlReq.needleReq.mockImplementation((p,cb) => cb(undefined));
+    const cl = jest.fn();
+    controller(cl);
+    expect(cl).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/needleSend.test.js
+++ b/__tests__/needleSend.test.js
@@ -1,0 +1,49 @@
+const needle = require('needle');
+const { needleReq } = require('../modules/needleSend');
+
+jest.mock('needle');
+
+describe('needleReq', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('calls callback with undefined when response is undefined', () => {
+    needle.request.mockImplementation((m,u,d,o,cb) => cb(null, undefined));
+    const cb = jest.fn();
+    needleReq({method:'GET', url:'http://test'}, cb);
+    expect(cb).toHaveBeenCalledWith(undefined);
+  });
+
+  test('passes through successful response', () => {
+    const resp = {statusCode: 200, body: {msg:'ok'}};
+    needle.request.mockImplementation((m,u,d,o,cb) => cb(null, resp));
+    const cb = jest.fn();
+    needleReq({method:'GET', url:'http://test'}, cb);
+    expect(cb).toHaveBeenCalledWith(resp);
+  });
+
+  test('passes through 204 response', () => {
+    const resp = {statusCode: 204, body: {}};
+    needle.request.mockImplementation((m,u,d,o,cb) => cb(null, resp));
+    const cb = jest.fn();
+    needleReq({method:'GET', url:'http://test'}, cb);
+    expect(cb).toHaveBeenCalledWith(resp);
+  });
+
+  test('still calls callback on non-200/204 status', () => {
+    const resp = {statusCode: 404, body: {}};
+    needle.request.mockImplementation((m,u,d,o,cb) => cb(null, resp));
+    const cb = jest.fn();
+    needleReq({method:'GET', url:'http://test'}, cb);
+    expect(cb).toHaveBeenCalledWith(resp);
+  });
+
+  test('does not call callback on 500', () => {
+    const resp = {statusCode: 500, body: {}};
+    needle.request.mockImplementation((m,u,d,o,cb) => cb(null, resp));
+    const cb = jest.fn();
+    needleReq({method:'GET', url:'http://test'}, cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/transcodingVideoControl.test.js
+++ b/__tests__/transcodingVideoControl.test.js
@@ -1,0 +1,27 @@
+const dbModel = require('../db-model');
+const { addToQueue } = require('../api/controllers/transcoding-video-control');
+
+jest.mock('../db-model');
+
+describe('addToQueue', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('does nothing if video already exists', async () => {
+    dbModel.one.mockResolvedValue({id:1});
+    const video = {uuid:'u', ext:'.mp4', resulotion:'720', id:123};
+    console.log = jest.fn();
+    await addToQueue(video);
+    expect(dbModel.none).not.toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith('Уже есть такое видео');
+  });
+
+  test('inserts into queue when new', async () => {
+    dbModel.one.mockRejectedValue(new Error('not found'));
+    dbModel.none.mockResolvedValue();
+    const video = {uuid:'u', ext:'.mp4', resulotion:'720', id:456};
+    await addToQueue(video);
+    expect(dbModel.none).toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Video transcoding server",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "sudo node ./server.js --stack_size=18192 --max-old-space-size=18192"
   },
   "repository": {
@@ -34,5 +34,8 @@
     "request-promise-native": "^1.0.7",
     "sequelize": "^5.19.1",
     "telegraf": "^3.36.0"
+  },
+  "devDependencies": {
+    "jest": "^30.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- set up Jest test runner
- add unit tests for needleSend module
- add unit tests for name-routs-streams controller
- add unit tests for addToQueue function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876130cb544832db4dd962b05218712