### PR TITLE
Fix Access-Control-Allow-Methods header

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ app.use(bodyParser.json({
 
 app.use(function (req, res, next) {
     res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+    res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
     res.setHeader('Access-Control-Allow-Credentials', true);
     next();


### PR DESCRIPTION
## Summary
- allow POST in Access-Control-Allow-Methods header

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68761c0aa918832d98a90aa335b4a34d