### PR TITLE
Fix SQL injection issue by validating sort parameter

### DIFF
--- a/api/controllers/statistics-control.js
+++ b/api/controllers/statistics-control.js
@@ -11,10 +11,25 @@ const dbModel = require("../../db-model");
  * ***/
 
 async function controller(req,res) {
+    const allowedSortFields = [
+        'id',
+        'status',
+        'uuid',
+        'downloaded',
+        'uploaded',
+        'transcoded',
+        'createdat'
+    ];
+
+    let sortField = req.query.sort;
+    if (!allowedSortFields.includes(sortField)) {
+        sortField = 'id';
+    }
+
     let pagination = {
-        offset: req.query.start?req.query.start:0,
-        limit:  req.query.count?req.query.count:10,
-        sort:  'ORDER BY ' + req.query.sort
+        offset: req.query.start ? req.query.start : 0,
+        limit:  req.query.count ? req.query.count : 10,
+        sort:  'ORDER BY ' + sortField
     };
     // console.log(pagination);
     //TODO Удалить нахуй pg-promis и перейти на ОРМ


### PR DESCRIPTION
## Summary
- sanitize `req.query.sort` in `statistics-control.js` to prevent SQL injection
- enforce allowed sort fields and default to `id`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68761c08ae3c832da7a69de9ab854841